### PR TITLE
fixups

### DIFF
--- a/pisa/core/bin_indexing.py
+++ b/pisa/core/bin_indexing.py
@@ -121,9 +121,9 @@ def lookup_indices(sample, binning):
 # Numba vectorized functions
 
 if FTYPE == np.float32:
-    _SIGNATURE = ["(f4[:], f4[:], f4[:])"]
+    _SIGNATURE = ["(f4[:], f4[:], i8[:])"]
 else:
-    _SIGNATURE = ["(f8[:], f8[:], f8[:])"]
+    _SIGNATURE = ["(f8[:], f8[:], i8[:])"]
 
 
 @guvectorize(_SIGNATURE, "(), (j) -> ()", target=TARGET)
@@ -134,9 +134,9 @@ def lookup_index_vectorized_1d(sample_x, bin_edges_x, out):
 
 
 if FTYPE == np.float32:
-    _SIGNATURE = ["(f4[:], f4[:], f4[:], f4[:], f4[:])"]
+    _SIGNATURE = ["(f4[:], f4[:], f4[:], f4[:], i8[:])"]
 else:
-    _SIGNATURE = ["(f8[:], f8[:], f8[:], f8[:], f8[:])"]
+    _SIGNATURE = ["(f8[:], f8[:], f8[:], f8[:], i8[:])"]
 
 
 @guvectorize(_SIGNATURE, "(), (), (j), (k) -> ()", target=TARGET)
@@ -164,9 +164,9 @@ def lookup_index_vectorized_2d(sample_x, sample_y, bin_edges_x, bin_edges_y, out
 
 
 if FTYPE == np.float32:
-    _SIGNATURE = ["(f4[:], f4[:], f4[:], f4[:], f4[:], f4[:], f4[:])"]
+    _SIGNATURE = ["(f4[:], f4[:], f4[:], f4[:], f4[:], f4[:], i8[:])"]
 else:
-    _SIGNATURE = ["(f8[:], f8[:], f8[:], f8[:], f8[:], f8[:], f8[:])"]
+    _SIGNATURE = ["(f8[:], f8[:], f8[:], f8[:], f8[:], f8[:], i8[:])"]
 
 
 @guvectorize(_SIGNATURE, "(), (), (), (j), (k), (l) -> ()", target=TARGET)
@@ -232,13 +232,12 @@ def test_lookup_indices():
     # All values higher or equal to the last bin edges are assigned an index of zero
     #
     logging.trace("TEST 1D:")
-    logging.trace("Total number of bins: ", 7)
-    logging.trace(
-        "array in 1D: ", x.get(WHERE), "\nBinning: ", (binning_1d.bin_edges[0])
-    )
+    logging.trace("Total number of bins: {}".format(7))
+    logging.trace("array in 1D: {}".format(x.get(WHERE)))
+    logging.trace("Binning: {}".format(binning_1d.bin_edges[0]))
     indices = lookup_indices([x], binning_1d)
-    logging.trace("indices of each array element:", indices.get(WHERE))
-    logging.trace("*********************************\n")
+    logging.trace("indices of each array element: {}".format(indices.get(WHERE)))
+    logging.trace("*********************************")
     assert np.array_equal(indices.get(WHERE), np.array([-1, 0, 1, 6, 6, 7, 6]))
 
     # 2D case:
@@ -247,16 +246,16 @@ def test_lookup_indices():
     #   [(x=0, y=0), (x=0, y=1), (x=1, y=0), ...]
     #
     logging.trace("TEST 2D:")
-    logging.trace("Total number of bins: ", 7 * 4)
+    logging.trace("Total number of bins: {}".format(7 * 4))
     logging.trace(
-        "array in 2D: ",
-        [(i, j) for i, j in zip(x.get(WHERE), y.get(WHERE))],
-        "\nBinning: ",
-        binning_2d.bin_edges,
+        "array in 2D: {}".format(
+            [(i, j) for i, j in zip(x.get(WHERE), y.get(WHERE))],
+        )
     )
+    logging.trace("Binning: {}".format(binning_2d.bin_edges))
     indices = lookup_indices([x, y], binning_2d)
-    logging.trace("indices of each array element:", indices.get(WHERE))
-    logging.trace("*********************************\n")
+    logging.trace("indices of each array element: {}".format(indices.get(WHERE)))
+    logging.trace("*********************************")
     assert np.array_equal(indices.get(WHERE), np.array([-1, 0, 5, 25, 26, 28, 26]))
 
     # 3D case:
@@ -265,16 +264,16 @@ def test_lookup_indices():
     #   [(x=0, y=0, z=0), (x=0, y=0, z=1), (x=0, y=1, z=0)...]
     #
     logging.trace("TEST 3D:")
-    logging.trace("Total number of bins: ", 7 * 4 * 2)
+    logging.trace("Total number of bins: {}".format(7 * 4 * 2))
     logging.trace(
-        "array in 3D: ",
-        [(i, j, k) for i, j, k in zip(x.get(WHERE), y.get(WHERE), z.get(WHERE))],
-        "\nBinning: ",
-        binning_3d.bin_edges,
+        "array in 3D: {}".format(
+            [(i, j, k) for i, j, k in zip(x.get(WHERE), y.get(WHERE), z.get(WHERE))]
+        )
     )
+    logging.trace("Binning: {}".format(binning_3d.bin_edges))
     indices = lookup_indices([x, y, z], binning_3d)
-    logging.trace("indices of each array element:", indices.get(WHERE))
-    logging.trace("*********************************\n")
+    logging.trace("indices of each array element: {}".format(indices.get(WHERE)))
+    logging.trace("*********************************")
     assert np.array_equal(indices.get(WHERE), np.array([-1, 0, 11, 51, 52, 56, 52]))
 
     logging.info("<< PASS : test_lookup_indices >>")

--- a/pisa/core/bin_indexing.py
+++ b/pisa/core/bin_indexing.py
@@ -1,6 +1,6 @@
 """
 Functions to retrieve the bin location of each elements
-of an array, inside a Container, based on its specified 
+of an array, inside a Container, based on its specified
 output binning.
 
 functions were adapted from translation.py
@@ -33,28 +33,27 @@ bin bound by that edge
 from __future__ import absolute_import, print_function, division
 
 import numpy as np
-from numba import guvectorize, SmartArray, cuda
+from numba import guvectorize, SmartArray
 
 from pisa import FTYPE, TARGET
 from pisa.core.binning import OneDimBinning, MultiDimBinning
 from pisa.utils.log import logging, set_verbosity
 from pisa.utils.numba_tools import WHERE
-from pisa.utils import vectorizer
 
 from translation import find_index
 
-__all__ = ['lookup_indices']
+__all__ = ["lookup_indices"]
 
 
 # ---------- Lookup methods ---------------
+
 
 def lookup_indices(sample, binning):
     """The inverse of histograming
 
     Paramters
-    --------
+    ---------
     sample : list of SmartArrays
-
 
     binning : PISA MultiDimBinning
 
@@ -65,7 +64,7 @@ def lookup_indices(sample, binning):
     this method works for 1d, 2d and 3d histogram only
 
     """
-    assert binning.num_dims in [1,2,3], 'can only do 1d, 2d and 3d at the moment'
+    assert binning.num_dims in [1, 2, 3], "can only do 1d, 2d and 3d at the moment"
 
     bin_edges = [edges.magnitude for edges in binning.bin_edges]
 
@@ -73,15 +72,19 @@ def lookup_indices(sample, binning):
 
     if binning.num_dims == 1:
 
-        assert len(sample) == 1,'ERROR: binning provided has 1 dimension, but sample provided has not'
-        
-        lookup_index_vectorized_1d(sample[0].get(WHERE),
-                                   bin_edges[0],
-                                   out=array.get(WHERE))
+        assert (
+            len(sample) == 1
+        ), "ERROR: binning provided has 1 dimension, but sample provided has not"
+
+        lookup_index_vectorized_1d(
+            sample[0].get(WHERE), bin_edges[0], out=array.get(WHERE)
+        )
 
     elif binning.num_dims == 2:
 
-        assert len(sample)==2,'ERROR: binning provided has 2 dimensions, but sample provided has not.'
+        assert (
+            len(sample) == 2
+        ), "ERROR: binning provided has 2 dimensions, but sample provided has not."
 
         lookup_index_vectorized_2d(
             sample[0].get(WHERE),
@@ -93,7 +96,9 @@ def lookup_indices(sample, binning):
 
     elif binning.num_dims == 3:
 
-        assert len(sample)==3,'ERROR: binning provided has 3 dimensions, but sample provided has not.'
+        assert (
+            len(sample) == 3
+        ), "ERROR: binning provided has 3 dimensions, but sample provided has not."
 
         lookup_index_vectorized_3d(
             sample[0].get(WHERE),
@@ -104,92 +109,102 @@ def lookup_indices(sample, binning):
             bin_edges[2],
             out=array.get(WHERE),
         )
-        
+
     else:
         raise NotImplementedError()
+
     array.mark_changed(WHERE)
     return array
 
 
-
-#-----------------------------------------------------------------------
+# -----------------------------------------------------------------------
 # Numba vectorized functions
 
 if FTYPE == np.float32:
-    _SIGNATURE = ['(f4[:], f4[:], f4[:])']
+    _SIGNATURE = ["(f4[:], f4[:], f4[:])"]
 else:
-    _SIGNATURE = ['(f8[:], f8[:], f8[:])']
+    _SIGNATURE = ["(f8[:], f8[:], f8[:])"]
 
-@guvectorize(_SIGNATURE, '(),(j)->()', target=TARGET)
-def lookup_index_vectorized_1d(sample_x, bin_edges_x, indices):
+
+@guvectorize(_SIGNATURE, "(), (j) -> ()", target=TARGET)
+def lookup_index_vectorized_1d(sample_x, bin_edges_x, out):
     sample_x_ = sample_x[0]
     idx = find_index(sample_x_, bin_edges_x)
-    indices[0] = idx
+    out[0] = idx
 
-
-
-#-----------------------------------------------------------------------
-# Numba vectorized functions
 
 if FTYPE == np.float32:
-    _SIGNATURE = ['(f4[:], f4[:], f4[:], f4[:], f4[:])']
+    _SIGNATURE = ["(f4[:], f4[:], f4[:], f4[:], f4[:])"]
 else:
-    _SIGNATURE = ['(f8[:], f8[:], f8[:], f8[:], f8[:])']
+    _SIGNATURE = ["(f8[:], f8[:], f8[:], f8[:], f8[:])"]
 
-@guvectorize(_SIGNATURE, '(),(),(j),(k)->()', target=TARGET)
-def lookup_index_vectorized_2d(sample_x, sample_y, bin_edges_x, bin_edges_y, indices):
+
+@guvectorize(_SIGNATURE, "(), (), (j), (k) -> ()", target=TARGET)
+def lookup_index_vectorized_2d(sample_x, sample_y, bin_edges_x, bin_edges_y, out):
     """Same as above, except we get back the index"""
     sample_x_ = sample_x[0]
     sample_y_ = sample_y[0]
 
     idx_x = find_index(sample_x_, bin_edges_x)
     idx_y = find_index(sample_y_, bin_edges_y)
-    N = (len(bin_edges_x)-1)*(len(bin_edges_y)-1)
 
-    if idx_x==-1 or idx_y==-1:
-        indices[0] = -1
-    elif idx_x==(len(bin_edges_x)-1) or idx_y==(len(bin_edges_y)-1):
-        indices[0] = N
+    n_x_bins = len(bin_edges_x) - 1
+    n_y_bins = len(bin_edges_y) - 1
+    n_bins = n_x_bins * n_y_bins
+
+    if idx_x == -1 or idx_y == -1:
+        # any dim underflowed
+        out[0] = -1
+    elif idx_x == n_x_bins or idx_y == n_y_bins:
+        # any dim overflowed
+        out[0] = n_bins
     else:
-        idx = idx_x*(len(bin_edges_y)-1) + idx_y
-        indices[0] = idx
-
+        idx = idx_x * n_y_bins + idx_y
+        out[0] = idx
 
 
 if FTYPE == np.float32:
-    _SIGNATURE = ['(f4[:], f4[:], f4[:], f4[:], f4[:], f4[:], f4[:])']
+    _SIGNATURE = ["(f4[:], f4[:], f4[:], f4[:], f4[:], f4[:], f4[:])"]
 else:
-    _SIGNATURE = ['(f8[:], f8[:], f8[:], f8[:], f8[:], f8[:], f8[:])']
+    _SIGNATURE = ["(f8[:], f8[:], f8[:], f8[:], f8[:], f8[:], f8[:])"]
 
-@guvectorize(_SIGNATURE, '(),(),(),(j),(k),(l)->()', target=TARGET)
-def lookup_index_vectorized_3d(sample_x, sample_y, sample_z,  bin_edges_x, bin_edges_y, bin_edges_z, indices):
+
+@guvectorize(_SIGNATURE, "(), (), (), (j), (k), (l) -> ()", target=TARGET)
+def lookup_index_vectorized_3d(
+    sample_x, sample_y, sample_z, bin_edges_x, bin_edges_y, bin_edges_z, out
+):
     """Vectorized gufunc to perform the lookup"""
     sample_x_ = sample_x[0]
     sample_y_ = sample_y[0]
     sample_z_ = sample_z[0]
+
     idx_x = find_index(sample_x_, bin_edges_x)
     idx_y = find_index(sample_y_, bin_edges_y)
     idx_z = find_index(sample_z_, bin_edges_z)
-    N = (len(bin_edges_x)-1)*(len(bin_edges_y)-1)*(len(bin_edges_z)-1)
 
-    if idx_x==-1 or idx_y==-1 or idx_z==-1:
-        indices[0] = -1
-    elif idx_x==(len(bin_edges_x)-1) or idx_y==(len(bin_edges_y)-1) or idx_z==(len(bin_edges_z)-1):
-        indices[0] = N
+    n_x_bins = len(bin_edges_x) - 1
+    n_y_bins = len(bin_edges_y) - 1
+    n_z_bins = len(bin_edges_z) - 1
+    n_bins = n_x_bins * n_y_bins * n_z_bins
+
+    if idx_x == -1 or idx_y == -1 or idx_z == -1:
+        # any dim underflowed
+        out[0] = -1
+    elif idx_x == n_x_bins or idx_y == n_y_bins or idx_z == n_z_bins:
+        # any dim overflowed
+        out[0] = n_bins
     else:
-        idx = (idx_x*(len(bin_edges_y)-1) + idx_y)*(len(bin_edges_z)-1) + idx_z
-        indices[0] = idx
-
-
+        idx = (idx_x * n_y_bins + idx_y) * n_z_bins + idx_z
+        out[0] = idx
 
 
 def test_lookup_indices():
-    """Unit tests for `histogram` function"""
+    """Unit tests for `lookup_indices` function"""
 
     #
-    # Test a variety of points. 
-    # Points falling exactly on the bound are included in the 
-    # 
+    # Test a variety of points.
+    # Points falling exactly on the bound are included in the
+    #
     n_evts = 100
 
     x = np.array([-5, 0.5, 1.5, 7.0, 6.5, 8.0, 6.5], dtype=FTYPE)
@@ -204,57 +219,67 @@ def test_lookup_indices():
 
     w = SmartArray(w)
 
-    binning_x = OneDimBinning(name='x', num_bins=7, is_lin=True, domain=[0, 7])
-    binning_y = OneDimBinning(name='y', num_bins=4, is_lin=True, domain=[0, 4])
-    binning_z = OneDimBinning(name='z', num_bins=2, is_lin=True, domain=[0, 2])
-    
+    binning_x = OneDimBinning(name="x", num_bins=7, is_lin=True, domain=[0, 7])
+    binning_y = OneDimBinning(name="y", num_bins=4, is_lin=True, domain=[0, 4])
+    binning_z = OneDimBinning(name="z", num_bins=2, is_lin=True, domain=[0, 2])
+
     binning_1d = MultiDimBinning([binning_x])
     binning_2d = MultiDimBinning([binning_x, binning_y])
     binning_3d = MultiDimBinning([binning_x, binning_y, binning_z])
-
 
     # 1D case: check that each event falls into its predicted bin
     #
     # All values higher or equal to the last bin edges are assigned an index of zero
     #
-    print('TEST 1D:')
-    print('Total number of bins: ',7)
-    print('array in 1D: ',x.get(WHERE),'\nBinning: ',(binning_1d.bin_edges[0]))
+    logging.trace("TEST 1D:")
+    logging.trace("Total number of bins: ", 7)
+    logging.trace(
+        "array in 1D: ", x.get(WHERE), "\nBinning: ", (binning_1d.bin_edges[0])
+    )
     indices = lookup_indices([x], binning_1d)
-    print('indices of each array element:',indices.get(WHERE))
-    print('*********************************\n')
-    assert np.array_equal(indices.get(WHERE),np.array([-1,0,1,6,6,7,6]))
+    logging.trace("indices of each array element:", indices.get(WHERE))
+    logging.trace("*********************************\n")
+    assert np.array_equal(indices.get(WHERE), np.array([-1, 0, 1, 6, 6, 7, 6]))
 
     # 2D case:
     #
-    # The binning edges are flattened as follow: [(x=0,y=0),(x=0,y=1),(x=1,y=0),...]
+    # The binning edges are flattened as follows:
+    #   [(x=0, y=0), (x=0, y=1), (x=1, y=0), ...]
     #
-    print('TEST 2D:')
-    print('Total number of bins: ',7*4)
-    print('array in 2D: ',[(i,j) for i,j in zip(x.get(WHERE),y.get(WHERE))],'\nBinning: ',binning_2d.bin_edges)
-    indices = lookup_indices([x,y], binning_2d)
-    print('indices of each array element:',indices.get(WHERE))
-    print('*********************************\n')
-    assert np.array_equal(indices.get(WHERE),np.array([-1,0,5,25,26,28,26]))
+    logging.trace("TEST 2D:")
+    logging.trace("Total number of bins: ", 7 * 4)
+    logging.trace(
+        "array in 2D: ",
+        [(i, j) for i, j in zip(x.get(WHERE), y.get(WHERE))],
+        "\nBinning: ",
+        binning_2d.bin_edges,
+    )
+    indices = lookup_indices([x, y], binning_2d)
+    logging.trace("indices of each array element:", indices.get(WHERE))
+    logging.trace("*********************************\n")
+    assert np.array_equal(indices.get(WHERE), np.array([-1, 0, 5, 25, 26, 28, 26]))
 
     # 3D case:
     #
-    # the binning edges are flattened as follow: [(x=0,y=0,z=0),(x=0,y=0,z=1),(x=0,y=1,z=0)...]
+    # the binning edges are flattened as follows:
+    #   [(x=0, y=0, z=0), (x=0, y=0, z=1), (x=0, y=1, z=0)...]
     #
-    print('TEST 3D:')
-    print('Total number of bins: ',7*4*2)
-    print('array in 3D: ',[(i,j,k) for i,j,k in zip(x.get(WHERE),y.get(WHERE),z.get(WHERE))],'\nBinning: ',binning_3d.bin_edges)
-    indices = lookup_indices([x,y,z], binning_3d)
-    print('indices of each array element:',indices.get(WHERE))
-    print('*********************************\n')
-    assert np.array_equal(indices.get(WHERE),np.array([-1,0,11,51,52,56,52]))
+    logging.trace("TEST 3D:")
+    logging.trace("Total number of bins: ", 7 * 4 * 2)
+    logging.trace(
+        "array in 3D: ",
+        [(i, j, k) for i, j, k in zip(x.get(WHERE), y.get(WHERE), z.get(WHERE))],
+        "\nBinning: ",
+        binning_3d.bin_edges,
+    )
+    indices = lookup_indices([x, y, z], binning_3d)
+    logging.trace("indices of each array element:", indices.get(WHERE))
+    logging.trace("*********************************\n")
+    assert np.array_equal(indices.get(WHERE), np.array([-1, 0, 11, 51, 52, 56, 52]))
+
+    logging.info("<< PASS : test_lookup_indices >>")
 
 
-
-
-
-    logging.info('<< PASS : test_lookup_indices>>')
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     set_verbosity(1)
     test_lookup_indices()

--- a/pisa/core/bin_indexing.py
+++ b/pisa/core/bin_indexing.py
@@ -42,7 +42,7 @@ from pisa.utils.numba_tools import WHERE
 
 from translation import find_index
 
-__all__ = ["lookup_indices"]
+__all__ = ["lookup_indices", "test_lookup_indices"]
 
 
 # ---------- Lookup methods ---------------

--- a/pisa/core/translation.py
+++ b/pisa/core/translation.py
@@ -21,8 +21,11 @@ from pisa.utils.numba_tools import myjit, WHERE
 from pisa.utils import vectorizer
 
 __all__ = [
+    'resample',
+    'get_hist',
     'histogram',
     'lookup',
+    'find_index',
     'resample',
 ]
 
@@ -299,7 +302,7 @@ def lookup(sample, flat_hist, binning):
 
     """
     #print(binning)
-    assert binning.num_dims in [2,3], 'can only do 2d and 3d at the moment'
+    assert binning.num_dims in [2, 3], 'can only do 2d and 3d at the moment'
     bin_edges = [edges.magnitude for edges in binning.bin_edges]
     # todo: directly return smart array
     if flat_hist.ndim == 1:
@@ -361,24 +364,24 @@ def find_index(x, bin_edges):
     direct transformations instead of search
     """
     # TODO: support lin and log binnings with
-    
+
     #
-    # First check: extreme bin
+    # First check: ouside binning
     #
-    if x<bin_edges[0]:
+    if x < bin_edges[0]:
         return -1
-    elif x>bin_edges[-1]:
-        return len(bin_edges)-1
+    elif x > bin_edges[-1]:
+        return len(bin_edges) - 1
     else:
         #
         # Now handle middle cases
         #
         first = 0
-        last = len(bin_edges) -1
+        last = len(bin_edges) - 1
         while first <= last:
             i = int((first + last)/2)
             if x > bin_edges[i]:
-                
+
                 if x <= bin_edges[i+1]:
                     break
                 else:
@@ -394,7 +397,7 @@ if FTYPE == np.float32:
 else:
     _SIGNATURE = ['(f8[:], f8[:], f8[:], f8[:], f8[:], f8[:])']
 
-@guvectorize(_SIGNATURE, '(),(),(j),(k),(l)->()', target=TARGET)
+@guvectorize(_SIGNATURE, '(), (), (j), (k), (l)->()', target=TARGET)
 def lookup_vectorized_2d(sample_x, sample_y, flat_hist, bin_edges_x, bin_edges_y, weights):
     """Vectorized gufunc to perform the lookup"""
     sample_x_ = sample_x[0]
@@ -413,11 +416,11 @@ def lookup_vectorized_2d(sample_x, sample_y, flat_hist, bin_edges_x, bin_edges_y
 
 
 if FTYPE == np.float32:
-    _SIGNATURE = ['(f4[:], f4[:], f4[:,:], f4[:], f4[:], f4[:])']
+    _SIGNATURE = ['(f4[:], f4[:], f4[:, :], f4[:], f4[:], f4[:])']
 else:
-    _SIGNATURE = ['(f8[:], f8[:], f8[:,:], f8[:], f8[:], f8[:])']
+    _SIGNATURE = ['(f8[:], f8[:], f8[:, :], f8[:], f8[:], f8[:])']
 
-@guvectorize(_SIGNATURE, '(),(),(j,d),(k),(l)->(d)', target=TARGET)
+@guvectorize(_SIGNATURE, '(), (), (j, d), (k), (l)->(d)', target=TARGET)
 def lookup_vectorized_2d_arrays(sample_x, sample_y, flat_hist, bin_edges_x, bin_edges_y, weights):
     """Vectorized gufunc to perform the lookup while flat hist and weights have
     both a second dimension
@@ -443,7 +446,7 @@ if FTYPE == np.float32:
 else:
     _SIGNATURE = ['(f8[:], f8[:], f8[:], f8[:], f8[:], f8[:], f8[:], f8[:])']
 
-@guvectorize(_SIGNATURE, '(),(),(),(j),(k),(l),(m)->()', target=TARGET)
+@guvectorize(_SIGNATURE, '(), (), (), (j), (k), (l), (m)->()', target=TARGET)
 def lookup_vectorized_3d(sample_x, sample_y, sample_z, flat_hist, bin_edges_x, bin_edges_y, bin_edges_z, weights):
     """Vectorized gufunc to perform the lookup"""
     sample_x_ = sample_x[0]
@@ -465,11 +468,11 @@ def lookup_vectorized_3d(sample_x, sample_y, sample_z, flat_hist, bin_edges_x, b
 
 
 if FTYPE == np.float32:
-    _SIGNATURE = ['(f4[:], f4[:], f4[:], f4[:,:], f4[:], f4[:], f4[:], f4[:])']
+    _SIGNATURE = ['(f4[:], f4[:], f4[:], f4[:, :], f4[:], f4[:], f4[:], f4[:])']
 else:
-    _SIGNATURE = ['(f8[:], f8[:], f8[:], f8[:,:], f8[:], f8[:], f8[:], f8[:])']
+    _SIGNATURE = ['(f8[:], f8[:], f8[:], f8[:, :], f8[:], f8[:], f8[:], f8[:])']
 
-@guvectorize(_SIGNATURE, '(),(),(),(j,d),(k),(l),(m)->(d)', target=TARGET)
+@guvectorize(_SIGNATURE, '(), (), (), (j, d), (k), (l), (m)->(d)', target=TARGET)
 def lookup_vectorized_3d_arrays(sample_x, sample_y, sample_z, flat_hist, bin_edges_x, bin_edges_y, bin_edges_z, weights):
     """Vectorized gufunc to perform the lookup while flat hist and weights have
     both a second dimension"""
@@ -519,26 +522,23 @@ def test_histogram():
 
     logging.info('<< PASS : test_histogram >>')
 
-def test_indices():
+def test_find_index():
+    """Unit tests for `find_index` function"""
     #
-    # Testing find_index 
+    # Testing find_index
     #
-    bin_edges = np.array([0.,1.,2.,3.,4.])
+    bin_edges = np.array([0., 1., 2., 3., 4.])
 
-    test_value = np.array([-3.,0.,1.,3.5,2.,3.,4.,4.5])
+    test_value = np.array([-3., 0., 1., 3.5, 2., 3., 4., 4.5])
 
-    expected_indices = np.array([-1,0,0,3,1,2,3,4])
-    indices = [find_index(x,bin_edges) for x in test_value]
+    expected_indices = np.array([-1, 0, 0, 3, 1, 2, 3, 4])
+    indices = [find_index(x, bin_edges) for x in test_value]
 
-    assert np.array_equal(indices,expected_indices)
+    assert np.array_equal(indices, expected_indices)
     logging.info('<< PASS : find_index >>')
-
 
 
 if __name__ == '__main__':
     set_verbosity(1)
-    test_indices()
+    test_find_index()
     test_histogram()
-
-
-

--- a/pisa/core/translation.py
+++ b/pisa/core/translation.py
@@ -27,6 +27,8 @@ __all__ = [
     'lookup',
     'find_index',
     'resample',
+    'test_histogram',
+    'test_find_index',
 ]
 
 

--- a/pisa/core/translation.py
+++ b/pisa/core/translation.py
@@ -535,7 +535,7 @@ def test_find_index():
     indices = [find_index(x, bin_edges) for x in test_value]
 
     assert np.array_equal(indices, expected_indices)
-    logging.info('<< PASS : find_index >>')
+    logging.info('<< PASS : test_find_index >>')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* black formatting for bin_indexing.py (won't re-format an existing file due to large diff it generates when merged back into i3os/pisa)
* Pylint fixups
* add `n_{x,y,z}_bins`, `n_bins` variables for clarity
* some added comments
* print statements in test functions -> `logging.trace` (when running a hundred unit tests, simply saying "pass" at the end is all that's really useful; but setting to trace level verbosity allows for seeing everything if we want)
* rename test function to match function being tested
* signed 64 bit integer outputs of `lookup_index_vectorized*` functions
* `__all__` updated